### PR TITLE
Add 'defaults' directive to call_data

### DIFF
--- a/sudo.py
+++ b/sudo.py
@@ -14,6 +14,7 @@ class Sudo(dotbot.Plugin):
             raise ValueError('sudo cannot handle directive %s' %
                 directive)
         
+        data = [{'defaults': self._context.defaults()}] + data
         call_data = {
                 'dotbot': path.dirname(path.dirname(dotbot.__file__)),
                 'plugins': [


### PR DESCRIPTION
Added passing 'defaults' directive with call_data so sudo commands can
benefit from previously defined defaults.